### PR TITLE
Configure application to disable workflist and annotation tools

### DIFF
--- a/etc/nginx/conf.d/local.conf
+++ b/etc/nginx/conf.d/local.conf
@@ -14,7 +14,7 @@ server {
 
     root /var/www/html;
 
-    location / {
+    location /viewer {
         try_files $uri $uri/ /index.html;
         add_header Access-Control-Allow-Origin *;
     }

--- a/public/config/local.js
+++ b/public/config/local.js
@@ -1,9 +1,10 @@
 window.config = {
-  path: "/",
-  /** This is an array, but we'll only use the first entry for now */
+  // This must match the location configured for web server
+  path: "/viewer",
   servers: [
     {
       id: "local",
+      // This must match the proxy location configured for the web server
       url: "http://localhost:8008/dicomweb",
       write: true
     }

--- a/public/config/local.js
+++ b/public/config/local.js
@@ -12,6 +12,8 @@ window.config = {
   {
     retrieveRendered: false
   },
+  disableWorklist: false,
+  disableAnnotationTools: false,
   annotations: [
     {
       finding: {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,7 +74,7 @@ class App extends React.Component<AppProps, AppState> {
    * @param user - Information about the user
    * @param authorization - Value of the "Authorization" HTTP header field
    */
-  handleSignIn = ({ user, authorization }: {
+  onSignIn = ({ user, authorization }: {
     user: User
     authorization: string
   }): void => {
@@ -91,7 +91,7 @@ class App extends React.Component<AppProps, AppState> {
 
   componentDidMount (): void {
     if (this.auth !== undefined) {
-      this.auth.signIn({ onSignIn: this.handleSignIn }).then(() => {
+      this.auth.signIn({ onSignIn: this.onSignIn }).then(() => {
         console.info('sign-in successful')
       }).catch((error) => {
         console.error('sign-in failed ', error)
@@ -115,12 +115,25 @@ class App extends React.Component<AppProps, AppState> {
       organization: this.props.config.organization
     }
 
+    let worklist
+    if (!this.props.config.disableWorklist) {
+      worklist = <Worklist client={this.state.client} />
+    } else {
+      worklist = <div>Worklist has been disabled.</div>
+    }
+
+    const layoutStyle = { height: '100vh' }
+    const layoutContentStyle = { height: '100%' }
+
     if (this.state.isLoading) {
       return (
         <BrowserRouter>
-          <Layout style={{ height: '100vh' }}>
-            <Header app={appInfo} />
-            <Layout.Content style={{ height: '100%' }}>
+          <Layout style={layoutStyle}>
+            <Header
+              app={appInfo}
+              showWorklistButton={false}
+            />
+            <Layout.Content style={layoutContentStyle}>
               <FaSpinner />
             </Layout.Content>
           </Layout>
@@ -129,10 +142,13 @@ class App extends React.Component<AppProps, AppState> {
     } else if (!this.state.wasAuthSuccessful) {
       return (
         <BrowserRouter>
-          <Layout style={{ height: '100vh' }}>
-            <Header app={appInfo} />
-            <Layout.Content style={{ height: '100%' }}>
-              <div>Error. Sign-in failed.</div>
+          <Layout style={layoutStyle}>
+            <Header
+              app={appInfo}
+              showWorklistButton={false}
+            />
+            <Layout.Content style={layoutContentStyle}>
+              <div>Sign-in failed.</div>
             </Layout.Content>
           </Layout>
         </BrowserRouter>
@@ -140,32 +156,43 @@ class App extends React.Component<AppProps, AppState> {
     } else {
       return (
         <BrowserRouter>
-          <Layout style={{ height: '100vh' }}>
-            <Header
-              app={appInfo}
-              user={this.state.user}
-            />
-            <Layout.Content style={{ height: '100%' }}>
-              <Switch>
-                <Route
-                  path='/studies/:StudyInstanceUID'
-                  render={(routeProps) => (
+          <Switch>
+            <Route
+              path='/studies/:StudyInstanceUID'
+              render={(routeProps) => (
+                <Layout style={layoutStyle}>
+                  <Header
+                    app={appInfo}
+                    user={this.state.user}
+                    showWorklistButton={!this.props.config.disableWorklist}
+                  />
+                  <Layout.Content style={layoutContentStyle}>
                     <CaseViewer
                       client={this.state.client}
                       user={this.state.user}
                       renderer={this.props.config.renderer}
                       annotations={this.props.config.annotations}
                       app={appInfo}
+                      enableAnnotationTools={!this.props.config.disableAnnotationTools}
                       studyInstanceUID={routeProps.match.params.StudyInstanceUID}
                     />
-                  )}
+                  </Layout.Content>
+                </Layout>
+              )}
+            />
+            <Route exact path='/'>
+              <Layout style={layoutStyle}>
+                <Header
+                  app={appInfo}
+                  user={this.state.user}
+                  showWorklistButton={false}
                 />
-                <Route exact path='/'>
-                  <Worklist client={this.state.client} />
-                </Route>
+                <Layout.Content style={layoutContentStyle}>
+                  {worklist}
+                </Layout.Content>
+              </Layout>
+            </Route>
               </Switch>
-            </Layout.Content>
-          </Layout>
         </BrowserRouter>
       )
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,7 +66,7 @@ class App extends React.Component<AppProps, AppState> {
   }
 
   /**
-   * Handler that gets called when a user successfully authenticated.
+   * Handle successful authentication event.
    *
    * Authorizes the DICOMweb client to access the DICOMweb server and directs
    * the user back to the App.
@@ -74,7 +74,7 @@ class App extends React.Component<AppProps, AppState> {
    * @param user - Information about the user
    * @param authorization - Value of the "Authorization" HTTP header field
    */
-  onSignIn = ({ user, authorization }: {
+  handleSignIn = ({ user, authorization }: {
     user: User
     authorization: string
   }): void => {
@@ -91,7 +91,7 @@ class App extends React.Component<AppProps, AppState> {
 
   componentDidMount (): void {
     if (this.auth !== undefined) {
-      this.auth.signIn({ onSignIn: this.onSignIn }).then(() => {
+      this.auth.signIn({ onSignIn: this.handleSignIn }).then(() => {
         console.info('sign-in successful')
       }).catch((error) => {
         console.error('sign-in failed ', error)
@@ -127,7 +127,7 @@ class App extends React.Component<AppProps, AppState> {
 
     if (this.state.isLoading) {
       return (
-        <BrowserRouter>
+        <BrowserRouter basename={this.props.config.path}>
           <Layout style={layoutStyle}>
             <Header
               app={appInfo}
@@ -141,7 +141,7 @@ class App extends React.Component<AppProps, AppState> {
       )
     } else if (!this.state.wasAuthSuccessful) {
       return (
-        <BrowserRouter>
+        <BrowserRouter basename={this.props.config.path}>
           <Layout style={layoutStyle}>
             <Header
               app={appInfo}
@@ -155,7 +155,7 @@ class App extends React.Component<AppProps, AppState> {
       )
     } else {
       return (
-        <BrowserRouter>
+        <BrowserRouter basename={this.props.config.path}>
           <Switch>
             <Route
               path='/studies/:StudyInstanceUID'

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,17 +36,16 @@ interface AppState {
 class App extends React.Component<AppProps, AppState> {
   private readonly auth?: AuthManager
 
-  private readonly baseUri: string
-
   constructor (props: AppProps) {
     super(props)
 
     const { protocol, host } = window.location
-    this.baseUri = joinUrl(props.config.path, `${protocol}//${host}`)
+    const baseUri = `${protocol}//${host}`
+    const appUri = joinUrl(props.config.path, baseUri)
 
     const oidcSettings = props.config.oidc
     if (oidcSettings !== undefined) {
-      this.auth = new OidcManager(this.baseUri, oidcSettings)
+      this.auth = new OidcManager(appUri, oidcSettings)
     }
 
     if (props.config.servers.length === 0) {
@@ -57,7 +56,7 @@ class App extends React.Component<AppProps, AppState> {
 
     this.state = {
       client: new DicomWebManager({
-        baseUri: this.baseUri,
+        baseUri: baseUri,
         settings: props.config.servers
       }),
       isLoading: true,

--- a/src/AppConfig.d.ts
+++ b/src/AppConfig.d.ts
@@ -53,4 +53,6 @@ export default interface AppConfig {
   annotations: AnnotationSettings[]
   organization?: string
   oidc?: OidcSettings
+  disableWorklist?: boolean
+  disableAnnotationTools?: boolean
 }

--- a/src/DicomWebManager.tsx
+++ b/src/DicomWebManager.tsx
@@ -19,15 +19,18 @@ export default class DicomWebManager {
         throw Error('At least one server needs to be configured.')
       }
 
-      const clientSettings: dwc.api.DICOMwebClientOptions = { url: '' }
+      let serviceUrl
       if (serverSettings.url !== undefined) {
-        clientSettings.url = serverSettings.url
+        serviceUrl = serverSettings.url
       } else if (serverSettings.path !== undefined) {
-        clientSettings.url = joinUrl(serverSettings.path, baseUri)
+        serviceUrl = joinUrl(serverSettings.path, baseUri)
       } else {
         throw new Error(
           'Either path or full URL needs to be configured for server.'
         )
+      }
+      const clientSettings: dwc.api.DICOMwebClientOptions = {
+        url: serviceUrl
       }
       if (serverSettings.qidoPathPrefix !== undefined) {
         clientSettings.qidoURLPrefix = serverSettings.qidoPathPrefix

--- a/src/components/CaseViewer.tsx
+++ b/src/components/CaseViewer.tsx
@@ -34,6 +34,7 @@ interface ViewerProps extends RouteComponentProps {
   }
   renderer: RendererSettings
   annotations: AnnotationSettings[]
+  enableAnnotationTools: boolean
   user?: {
     name: string
     email: string
@@ -193,6 +194,7 @@ class Viewer extends React.Component<ViewerProps, ViewerState> {
                 seriesInstanceUID={routeProps.match.params.SeriesInstanceUID}
                 slides={this.state.slides}
                 annotations={this.props.annotations}
+                enableAnnotationTools={this.props.enableAnnotationTools}
                 app={this.props.app}
                 user={this.props.user}
               />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,6 +15,7 @@ interface HeaderProps {
     name: string
     email: string
   }
+  showWorklistButton: boolean
 }
 
 /**
@@ -33,14 +34,22 @@ class Header extends React.Component<HeaderProps, {}> {
         </>
       )
     }
+
+    let worklistButton
+    if (this.props.showWorklistButton) {
+      worklistButton = (
+        <NavLink to='/'>
+          <Button icon={<FaList />} />
+        </NavLink>
+      )
+    }
+
     return (
       <Layout.Header style={{ width: '100%', padding: '0 14px' }}>
         <Row>
           <Col>
             <Space align='center' direction='horizontal'>
-              <NavLink to='/'>
-                <Button icon={<FaList />} />
-              </NavLink>
+              {worklistButton}
             </Space>
           </Col>
           <Col flex='auto' />

--- a/src/components/SlideViewer.tsx
+++ b/src/components/SlideViewer.tsx
@@ -117,6 +117,7 @@ interface SlideViewerProps extends RouteComponentProps {
   }
   renderer: RendererSettings
   annotations: AnnotationSettings[]
+  enableAnnotationTools: boolean
   user?: {
     name: string
     email: string
@@ -1119,52 +1120,64 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
       }
     }
 
+    let toolbar
+    let toolbarHeight = '0px'
+    if (this.props.enableAnnotationTools) {
+      toolbar = (
+        <Row>
+          <Button
+            isToggle
+            tooltip='Draw ROI'
+            icon={FaDrawPolygon}
+            onClick={handlePolygonRoiDrawing}
+          />
+          <Button
+            isToggle
+            tooltip='Measure'
+            icon={FaRuler}
+            onClick={handleLineRoiDrawing}
+          />
+          <Button
+            isToggle
+            tooltip='Modify ROIs'
+            icon={FaHandPointer}
+            onClick={this.handleRoiModification}
+          />
+          <Button
+            isToggle
+            tooltip='Shift ROIs'
+            icon={FaHandPaper}
+            onClick={this.handleRoiTranslation}
+          />
+          <Button
+            tooltip='Remove selected ROI'
+            onClick={this.handleRoiRemoval}
+            icon={FaTrash}
+          />
+          <Button
+            isToggle
+            tooltip='Show/Hide ROIs'
+            icon={FaEye}
+            onClick={this.handleRoiVisibility}
+          />
+          <Button
+            tooltip='Save ROIs'
+            icon={FaSave}
+            onClick={this.handleReportGeneration}
+          />
+        </Row>
+      )
+      toolbarHeight = '50px'
+    }
+
     return (
       <Layout style={{ height: '100%' }} hasSider>
         <Layout.Content style={{ height: '100%' }}>
-          <Row>
-            <Button
-              isToggle
-              tooltip='Draw ROI'
-              icon={FaDrawPolygon}
-              onClick={handlePolygonRoiDrawing}
-            />
-            <Button
-              isToggle
-              tooltip='Measure'
-              icon={FaRuler}
-              onClick={handleLineRoiDrawing}
-            />
-            <Button
-              isToggle
-              tooltip='Modify ROIs'
-              icon={FaHandPointer}
-              onClick={this.handleRoiModification}
-            />
-            <Button
-              isToggle
-              tooltip='Shift ROIs'
-              icon={FaHandPaper}
-              onClick={this.handleRoiTranslation}
-            />
-            <Button
-              tooltip='Remove selected ROI'
-              onClick={this.handleRoiRemoval}
-              icon={FaTrash}
-            />
-            <Button
-              isToggle
-              tooltip='Show/Hide ROIs'
-              icon={FaEye}
-              onClick={this.handleRoiVisibility}
-            />
-            <Button
-              tooltip='Save ROIs'
-              icon={FaSave}
-              onClick={this.handleReportGeneration}
-            />
-          </Row>
-          <div style={{ height: 'calc(100% - 50px)' }} ref={this.volumeViewport} />
+          {toolbar}
+          <div
+            style={{ height: `calc(100% - ${toolbarHeight})` }}
+            ref={this.volumeViewport}
+          />
 
           <Modal
             visible={this.state.isAnnotationModalVisible}


### PR DESCRIPTION
This PR adds two configuration parameters to address #42:

* `disableWorklist` to disable the worklist. If `true` users can then no longer route to the worklist to select a study, but have to route to a specific study directly.
* `disableAnnotationTools` to disable the annotation tools of the slide viewer. If `true` users can no longer draw new annotation or edit existing annotations. However, existing annotations will still be displayed.