### PR TITLE
Update dep dicom-microscopy-viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "craco-less": "^1.17.0",
     "dcmjs": "^0.16.7",
     "dicomweb-client": "^0.8.2",
-    "dicom-microscopy-viewer": "^0.32.2",
+    "dicom-microscopy-viewer": "^0.33.0",
     "oidc-client": "^1.11.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",


### PR DESCRIPTION
https://github.com/MGHComputationalPathology/dicom-microscopy-viewer/releases/tag/v0.33.0 that update OpenLayers tp 6.7.0